### PR TITLE
Fixed itemframes not releasing items

### DIFF
--- a/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
+++ b/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
@@ -118,10 +118,8 @@ public class LWCPlayerListener implements Listener {
 						event.isCancelled())) {
 					event.setCancelled(true);
 				}
-			} else {
-				return;
 			}
-			if (protection != null) {
+			if (!event.isCancelled() && protection != null) {
 				boolean canAccess = lwc.canAccessProtection(p, protection);
 				if (canAccess) {
 					protection.remove();
@@ -190,6 +188,7 @@ public class LWCPlayerListener implements Listener {
 
 	@EventHandler
 	public void onEntityDamage(EntityDamageEvent e) {
+		if(e instanceof EntityDamageByEntityEvent) return; // handle this separately
 		Entity entity = e.getEntity();
 		int A = 50000 + entity.getUniqueId().hashCode();
 
@@ -204,6 +203,7 @@ public class LWCPlayerListener implements Listener {
 
 	@EventHandler
 	public void itemFrameItemRemoval(EntityDamageByEntityEvent e) {
+		if(e.isCancelled()) return; // don't need to check if needs canceling if already canceled
 		Entity entity = e.getEntity();
 		int A = 50000 + entity.getUniqueId().hashCode();
 		LWC lwc = LWC.getInstance();
@@ -234,19 +234,13 @@ public class LWCPlayerListener implements Listener {
 				}
 			}
 			if (entity instanceof ItemFrame) {
-				if (protection != null) {
-					boolean canAccess = lwc.canAccessProtection(p, protection);
-					if (canAccess)
-						return;
+				if (protection != null && !lwc.canAccessProtection(p, protection)) {
 					e.setCancelled(true);
 				}
 				return;
 			}
 			if (entity instanceof Painting) {
-				if (protection != null) {
-					boolean canAccess = lwc.canAccessProtection(p, protection);
-					if (canAccess)
-						return;
+				if (protection != null && !lwc.canAccessProtection(p, protection)){
 					e.setCancelled(true);
 				}
 				return;

--- a/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
+++ b/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
@@ -188,7 +188,8 @@ public class LWCPlayerListener implements Listener {
 
 	@EventHandler
 	public void onEntityDamage(EntityDamageEvent e) {
-		if(e instanceof EntityDamageByEntityEvent) return; // handle this separately
+		if(e instanceof EntityDamageByEntityEvent
+			&& !(e.getCause() == DamageCause.BLOCK_EXPLOSION || e.getCause() == DamageCause.ENTITY_EXPLOSION)) return; // handle this separately
 		Entity entity = e.getEntity();
 		int A = 50000 + entity.getUniqueId().hashCode();
 
@@ -467,8 +468,8 @@ public class LWCPlayerListener implements Listener {
 	public void onMoveItem(InventoryMoveItemEvent event) {
 		boolean result;
 
-		// if the initiator is the same as the source it is a dropper i.e.
-		// depositing items
+		// if the initiator is the same as the source it is a dropper or hopper
+		// i.e. depositing items
 		if (event.getInitiator() == event.getSource()) {
 			result = handleMoveItemEvent(event.getInitiator(),
 					event.getDestination());


### PR DESCRIPTION
Config: 
        ITEM_FRAME:
            enabled: true
            autoRegister: private

Before: needed to /unlock in order to remove an item from your own itemframe - fixed this by skipping generic entity damage even if it's an entity damage by entity event